### PR TITLE
Email-based imports

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -12,13 +12,14 @@ else:
     settings = {}
 
 ARG_DEFINITIONS = {
+    'BASE_DIRECTORY': 'Path to where files are located.',
     'FILE': 'File to decrypt.',
     'PGP_KEY': 'Full key for PGP',
     'PGP_PASS': 'Pass phrase for PGP'
 }
 
 REQUIRED_ARGS = [
-    'FILE', 'PGP_KEY', 'PGP_PASS'
+    'BASE_DIRECTORY', 'FILE', 'PGP_KEY', 'PGP_PASS'
 ]
 
 def main(args):
@@ -30,14 +31,14 @@ def main(args):
             all_required_args_set = False
 
     if all_required_args_set:
-        message = pgpy.PGPMessage.from_file('/tmp/%s' % args.FILE)
+        message = pgpy.PGPMessage.from_file('%s%s' % (args.BASE_DIRECTORY, args.FILE))
         private_key, _ = pgpy.PGPKey.from_blob(args.PGP_KEY)
 
         with private_key.unlock(args.PGP_PASS):
             csv = private_key.decrypt(message).message.decode("utf-8")
 
         new_file_name = '.'.join(args.FILE.split('.')[:-1])
-        file = open("/tmp/%s" % new_file_name, "w")
+        file = open("%s%s" % (args.BASE_DIRECTORY, new_file_name), "w")
         file.write(csv)
         file.close()
 

--- a/download.py
+++ b/download.py
@@ -11,6 +11,7 @@ else:
     settings = {}
 
 ARG_DEFINITIONS = {
+    'BASE_DIRECTORY': 'Path to where files are located.',
     'DATE': 'Date of files to download.',
     'SFTP_HOST': 'Host for SFTP connection.',
     'SFTP_USER': 'User for SFTP connection.',
@@ -18,7 +19,7 @@ ARG_DEFINITIONS = {
 }
 
 REQUIRED_ARGS = [
-    'DATE', 'SFTP_HOST', 'SFTP_USER', 'SFTP_PASS'
+    'BASE_DIRECTORY', 'DATE', 'SFTP_HOST', 'SFTP_USER', 'SFTP_PASS'
 ]
 
 def main(args):
@@ -39,7 +40,7 @@ def main(args):
         downloaded = []
         for file_name in file_list:
             if args.DATE in file_name:
-                sftp.get(file_name, '/tmp/%s' % file_name)
+                sftp.get(file_name, '%s%s' % (args.BASE_DIRECTORY, file_name))
                 downloaded.append(file_name)
         return downloaded
 

--- a/import_to_ak.py
+++ b/import_to_ak.py
@@ -11,6 +11,7 @@ else:
     settings = {}
 
 ARG_DEFINITIONS = {
+    'BASE_DIRECTORY': 'Path to where files are located.',
     'CSV': 'CSV file to import.',
     'AK_BASEURL': 'ActionKit Base URL.',
     'AK_USER': 'ActionKit API username.',
@@ -19,7 +20,7 @@ ARG_DEFINITIONS = {
 }
 
 REQUIRED_ARGS = [
-    'CSV', 'AK_BASEURL', 'AK_USER', 'AK_PASSWORD', 'AK_IMPORT_PAGE'
+    'BASE_DIRECTORY', 'CSV', 'AK_BASEURL', 'AK_USER', 'AK_PASSWORD', 'AK_IMPORT_PAGE'
 ]
 
 def main(args):
@@ -32,7 +33,7 @@ def main(args):
 
     if all_required_args_set:
         api = AKUserAPI(args)
-        result = api.bulk_upload(args.AK_IMPORT_PAGE, open('/tmp/' + args.CSV, 'rb'), 1)
+        result = api.bulk_upload(args.AK_IMPORT_PAGE, open('%s%s' % (args.BASE_DIRECTORY, args.CSV), 'rb'), 1)
         return result
 
 if __name__ == '__main__':

--- a/process.py
+++ b/process.py
@@ -92,7 +92,7 @@ def main(args):
                     for split_file in date_split_files:
                         args.CSV = split_file
                         import_to_ak.main(args)
-                        if "donations.csv" in args.CSV:
+                        if "donations-email.csv" in args.CSV or "donations-user.csv" in args.CSV:
                             args.TEXT = summarize.main(args)
                             print('Notifying...')
                             notify.main(args)

--- a/split.py
+++ b/split.py
@@ -10,9 +10,12 @@ if os.path.exists(os.path.join(BASE_DIR, 'settings.py')):
 else:
     settings = {}
 
-ARG_DEFINITIONS = {'CSV': 'CSV file to split.'}
+ARG_DEFINITIONS = {
+    'BASE_DIRECTORY': 'Path to where files are located.',
+    'CSV': 'CSV file to split.'
+}
 
-REQUIRED_ARGS = ['CSV']
+REQUIRED_ARGS = ['BASE_DIRECTORY', 'CSV']
 
 def main(args):
     all_required_args_set = True
@@ -35,7 +38,7 @@ def main(args):
         for column in set_only_columns:
             files[column] = []
 
-        with open('/tmp/' + args.CSV, 'rt') as csvfile:
+        with open('%s%s' % (args.BASE_DIRECTORY, args.CSV), 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
             for row in csvreader:
                 user_id = row.get('user_id')
@@ -82,7 +85,7 @@ def main(args):
             if len(files[file]) > 0:
                 filename = prefix + '-' + file + '.csv'
                 filenames.append(filename)
-                with open('/tmp/' + filename, 'w') as csvfile:
+                with open('%s%s' % (args.BASE_DIRECTORY, filename), 'w') as csvfile:
                     fieldnames = list(files[file][0].keys())
                     writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
                     writer.writeheader()

--- a/split.py
+++ b/split.py
@@ -34,9 +34,17 @@ def main(args):
         address_columns = [
             'address1', 'address2', 'city', 'state', 'zip'
         ]
-        files = {'donations': [], 'invalid': [], 'address': []}
+        files = {
+            'donations-user': [],
+            'donations-email': [],
+            'invalid-user': [],
+            'invalid-email': [],
+            'address-user': [],
+            'address-email': []
+        }
         for column in set_only_columns:
-            files[column] = []
+            files['%s-user' % column] = []
+            files['%s-email' % column] = []
 
         with open('%s%s' % (args.BASE_DIRECTORY, args.CSV), 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
@@ -44,40 +52,76 @@ def main(args):
                 user_id = row.get('user_id')
                 donation_payment_account = row.get('donation_payment_account')
                 source = row.get('source')
+                email = row.get('Email')
                 if float(row.get('donation_amount', 0)) > 0:
-                    files['donations'].append({
-                        'user_id': user_id, 'source': source,
-                        'donation_amount': row.get('donation_amount'),
-                        'donation_import_id': row.get('donation_import_id'),
-                        'donation_date': row.get('donation_date'),
-                        'donation_currency': row.get('donation_currency'),
-                        'donation_payment_account': donation_payment_account,
-                        'action_occupation': row.get('action_occupation'),
-                        'action_employer': row.get('action_employer'),
-                    })
+                    if user_id != '':
+                        files['donations-user'].append({
+                            'user_id': user_id, 'source': source,
+                            'donation_amount': row.get('donation_amount'),
+                            'donation_import_id': row.get('donation_import_id'),
+                            'donation_date': row.get('donation_date'),
+                            'donation_currency': row.get('donation_currency'),
+                            'donation_payment_account': donation_payment_account,
+                            'action_occupation': row.get('action_occupation'),
+                            'action_employer': row.get('action_employer'),
+                        })
+                    elif email != '':
+                        files['donations-email'].append({
+                            'email': email, 'source': source,
+                            'donation_amount': row.get('donation_amount'),
+                            'donation_import_id': row.get('donation_import_id'),
+                            'donation_date': row.get('donation_date'),
+                            'donation_currency': row.get('donation_currency'),
+                            'donation_payment_account': donation_payment_account,
+                            'action_occupation': row.get('action_occupation'),
+                            'action_employer': row.get('action_employer'),
+                        })
                 for column in set_only_columns:
                     row_column = row.get(column, '')
                     if row_column != '':
-                        files[column].append({
-                            'user_id': user_id, 'source': source,
-                            column: row.get(column),
-                        })
+                        if user_id != '':
+                            files['%s-user' % column].append({
+                                'user_id': user_id, 'source': source,
+                                column: row.get(column),
+                            })
+                        elif email != '':
+                            files['%s-email' % column].append({
+                                'email': email, 'source': source,
+                                column: row.get(column),
+                            })
 
                 if row.get('address1', False) == 'Invalid':
-                    files['invalid'].append({
-                        'user_id': user_id, 'source': source,
-                        'address1': '-', 'address2': '-', 'city': '-',
-                        'state': '-', 'zip': '-'
-                    })
+                    if user_id != '':
+                        files['invalid-user'].append({
+                            'user_id': user_id, 'source': source,
+                            'address1': '-', 'address2': '-', 'city': '-',
+                            'state': '-', 'zip': '-'
+                        })
+                    elif email != '':
+                        files['invalid-email'].append({
+                            'email': email, 'source': source,
+                            'address1': '-', 'address2': '-', 'city': '-',
+                            'state': '-', 'zip': '-'
+                        })
                 elif row.get('address1', False):
-                    files['address'].append({
-                        'user_id': user_id, 'source': source,
-                        'address1': row.get('address1', ''),
-                        'address2': row.get('address2', ''),
-                        'city': row.get('city', ''),
-                        'state': row.get('state', ''),
-                        'zip': row.get('zip', '')
-                    })
+                    if user_id != '':
+                        files['address-user'].append({
+                            'user_id': user_id, 'source': source,
+                            'address1': row.get('address1', ''),
+                            'address2': row.get('address2', ''),
+                            'city': row.get('city', ''),
+                            'state': row.get('state', ''),
+                            'zip': row.get('zip', '')
+                        })
+                    elif email != '':
+                        files['address-email'].append({
+                            'email': email, 'source': source,
+                            'address1': row.get('address1', ''),
+                            'address2': row.get('address2', ''),
+                            'city': row.get('city', ''),
+                            'state': row.get('state', ''),
+                            'zip': row.get('zip', '')
+                        })
 
         filenames = []
 

--- a/summarize.py
+++ b/summarize.py
@@ -10,12 +10,11 @@ else:
     settings = {}
 
 ARG_DEFINITIONS = {
+    'BASE_DIRECTORY': 'Path to where files are located.',
     'CSV': 'CSV of donation records.'
 }
 
-REQUIRED_ARGS = [
-    'CSV'
-]
+REQUIRED_ARGS = ['BASE_DIRECTORY', 'CSV']
 
 def main(args):
     all_required_args_set = True
@@ -27,7 +26,7 @@ def main(args):
 
     if all_required_args_set:
         donations = []
-        with open('/tmp/' + args.CSV, 'rt') as csvfile:
+        with open('%s%s' % (args.BASE_DIRECTORY, args.CSV), 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
             for row in csvreader:
                 date = row.get('donation_date')

--- a/test_split.py
+++ b/test_split.py
@@ -32,6 +32,7 @@ class Test:
                 'home_phone': ''
             })
         args = {
+            'BASE_DIRECTORY': '/tmp/',
             'CSV': 'merkletest.csv'
         }
         args = Struct(**args)

--- a/test_split.py
+++ b/test_split.py
@@ -40,25 +40,25 @@ class Test:
         files = main(args)
         # Make sure correct files were created
         correct_files = [
-            'merkletest-address.csv',
-            'merkletest-donations.csv',
-            'merkletest-first_name.csv',
-            'merkletest-invalid.csv',
-            'merkletest-last_name.csv'
+            'merkletest-address-user.csv',
+            'merkletest-donations-user.csv',
+            'merkletest-first_name-user.csv',
+            'merkletest-invalid-user.csv',
+            'merkletest-last_name-user.csv'
         ]
         assert set(files) == set(correct_files)
         # Make sure file contents are correct
-        with open('/tmp/merkletest-invalid.csv', 'rt') as csvfile:
+        with open('/tmp/merkletest-invalid-user.csv', 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
             rows = list(csvreader)
             assert len(rows) == 1
             assert rows[0].get('address1', '') == '-'
-        with open('/tmp/merkletest-donations.csv', 'rt') as csvfile:
+        with open('/tmp/merkletest-donations-user.csv', 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
             rows = list(csvreader)
             assert len(rows) == 1
             assert rows[0].get('donation_amount', '') == '100'
-        with open('/tmp/merkletest-first_name.csv', 'rt') as csvfile:
+        with open('/tmp/merkletest-first_name-user.csv', 'rt') as csvfile:
             csvreader = csv.DictReader(csvfile)
             rows = list(csvreader)
             assert len(rows) == 2


### PR DESCRIPTION
This allows members to be identified by email or user ID, where previously the scripts assumed user IDs. We're using this to accept donations from new members via postal mail. We're not actually getting their emails, just supplying fake example.com emails for them so ActionKit will accept the donation imports. So these donations won't be connected to any other activity these folks may have done or will do in ActionKit.

This also adds a new BASE_DIRECTORY an argument, previously hard-coded to /tmp. It still needs to be /tmp on Lambda, but for local testing, it's often easier to save the files in another directory.